### PR TITLE
fix: Use PAT for GHCR authentication

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -40,8 +40,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
 
       - name: Extract metadata
         id: meta


### PR DESCRIPTION
## Summary

- Switch from `GITHUB_TOKEN` to `CR_PAT` secret for GHCR authentication
- `GITHUB_TOKEN` has limited package creation permissions for organization repos
- This resolves the 403 Forbidden errors when pushing Docker images

## Test plan

- [ ] Merge PR to main
- [ ] Verify workflow runs successfully
- [ ] Confirm all 3 images (backend, frontend, open5gs) are pushed to GHCR

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)