### PR TITLE
fix: Pass SIM auth keys to backend container

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -240,6 +240,9 @@ services:
       - APP_NAME=Open5G2GO API
       # Host IP for eNodeB configuration display (Docker host IP that eNodeBs connect to)
       - HOST_IP=${HOST_IP:-10.48.0.110}
+      # SIM authentication keys (configured by setup-wizard)
+      - OPEN5GS_DEFAULT_K=${OPEN5GS_DEFAULT_K}
+      - OPEN5GS_DEFAULT_OPC=${OPEN5GS_DEFAULT_OPC}
       # Google SAS API Configuration (optional - for CBRS grant monitoring)
       # Set GOOGLE_APPLICATION_CREDENTIALS to service account JSON path
       - GOOGLE_APPLICATION_CREDENTIALS=/app/config/sas-service-account.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -256,6 +256,9 @@ services:
       - APP_NAME=Open5G2GO API
       # Host IP for eNodeB configuration display (Docker host IP that eNodeBs connect to)
       - HOST_IP=${HOST_IP:-10.48.0.110}
+      # SIM authentication keys (configured by setup-wizard)
+      - OPEN5GS_DEFAULT_K=${OPEN5GS_DEFAULT_K}
+      - OPEN5GS_DEFAULT_OPC=${OPEN5GS_DEFAULT_OPC}
       # Google SAS API Configuration (optional - for CBRS grant monitoring)
       # Set GOOGLE_APPLICATION_CREDENTIALS to service account JSON path
       - GOOGLE_APPLICATION_CREDENTIALS=/app/config/sas-service-account.json


### PR DESCRIPTION
## Summary
- Add `OPEN5GS_DEFAULT_K` and `OPEN5GS_DEFAULT_OPC` environment variables to backend service
- Fixes both `docker-compose.yml` and `docker-compose.prod.yml`

Fixes #6

## Test plan
- [ ] Deploy on test machine with `docker compose -f docker-compose.prod.yml up -d`
- [ ] Verify backend container has the env vars: `docker exec open5g2go-backend env | grep OPEN5GS`
- [ ] Add a subscriber via Web UI - should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)