### PR TITLE
docs: Sync public docs with repo and add API reference

### DIFF
--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -1,0 +1,562 @@
+# API Reference
+
+Open5G2GO provides a REST API for programmatic access to subscriber management and system monitoring.
+
+## Overview
+
+| Property | Value |
+|----------|-------|
+| Base URL | `http://YOUR_HOST:8080/api/v1` |
+| Content-Type | `application/json` |
+| Authentication | None (MVP) |
+
+### Interactive Documentation
+
+The API provides interactive documentation at runtime:
+
+- **Swagger UI**: `http://YOUR_HOST:8080/api/v1/docs`
+- **ReDoc**: `http://YOUR_HOST:8080/api/v1/redoc`
+- **OpenAPI Schema**: `http://YOUR_HOST:8080/api/v1/openapi.json`
+
+---
+
+## Health & System Endpoints
+
+### Health Check
+
+Check if the API is operational.
+
+```
+GET /api/v1/health
+```
+
+**Response:**
+```json
+{
+  "status": "healthy",
+  "version": "0.1.0",
+  "service": "Open5G2GO Web API"
+}
+```
+
+### System Status
+
+Get overall system health and statistics.
+
+```
+GET /api/v1/status
+```
+
+**Response:**
+```json
+{
+  "timestamp": "2024-01-15 10:30:00 UTC",
+  "system_name": "Open5G2GO",
+  "subscribers": {
+    "provisioned": 10,
+    "registered": 1,
+    "connected": 1
+  },
+  "enodebs": {
+    "total": 1,
+    "list": []
+  },
+  "health": {
+    "core_operational": true,
+    "database_connected": true,
+    "has_active_connections": true,
+    "enodebs_connected": true,
+    "operational_status": "fully_operational"
+  }
+}
+```
+
+### Service Status
+
+Get status of all Open5GS core services.
+
+```
+GET /api/v1/services
+```
+
+**Response:**
+```json
+{
+  "host": "localhost",
+  "timestamp": "2024-01-15T10:30:00.000000",
+  "check_method": "docker",
+  "services": [
+    {
+      "name": "mme",
+      "display_name": "MME (Mobility Management Entity)",
+      "category": "4G EPC Core",
+      "status": "running",
+      "uptime": null,
+      "last_checked": "2024-01-15T10:30:00.000000",
+      "details": "Docker: a1b2c3d4e5f6"
+    }
+  ],
+  "summary": {
+    "total": 7,
+    "running": 5,
+    "stopped": 2,
+    "error": 0,
+    "unknown": 0
+  }
+}
+```
+
+---
+
+## Subscriber Management
+
+### List All Subscribers
+
+Retrieve all provisioned subscribers.
+
+```
+GET /api/v1/subscribers
+```
+
+**Response:**
+```json
+{
+  "timestamp": "2024-01-15 10:30:00 UTC",
+  "total": 10,
+  "host": "Open5G2GO",
+  "subscribers": [
+    {
+      "imsi": "315010000000001",
+      "name": "CAM-01",
+      "apn": "internet",
+      "ip": "10.48.99.2"
+    }
+  ]
+}
+```
+
+### Get Subscriber Details
+
+Retrieve detailed information for a specific subscriber.
+
+```
+GET /api/v1/subscribers/{imsi}
+```
+
+**Path Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `imsi` | string | 15-digit IMSI (e.g., `315010000000001`) |
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "imsi": "315010000000001",
+  "ambr": {
+    "uplink": "100 Mbps",
+    "downlink": "100 Mbps"
+  },
+  "data": {
+    "imsi": "315010000000001",
+    "security": {
+      "k": "...",
+      "opc": "..."
+    },
+    "slice": [...]
+  }
+}
+```
+
+**Response (404 Not Found):**
+```json
+{
+  "error": "Subscriber not found",
+  "details": "No subscriber with IMSI 315010000000001"
+}
+```
+
+### Add Subscriber
+
+Provision a new subscriber (SIM card) on the network.
+
+```
+POST /api/v1/subscribers
+```
+
+**Request Body:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `imsi` | string | Yes | Full 15-digit IMSI from SIM card |
+| `name` | string | No | Friendly device name (max 50 chars) |
+| `apn` | string | No | Access Point Name (default: "internet") |
+| `ip` | string | No | Static IP address (auto-assigned if omitted) |
+
+**Example Request:**
+```json
+{
+  "imsi": "315010000000001",
+  "name": "Camera-01",
+  "apn": "internet"
+}
+```
+
+**Response (201 Created):**
+```json
+{
+  "success": true,
+  "timestamp": "2024-01-15 10:30:00 UTC",
+  "subscriber": {
+    "imsi": "315010000000001",
+    "name": "Camera-01",
+    "ip": "10.48.99.2",
+    "apn": "internet"
+  }
+}
+```
+
+**Response (400 Bad Request):**
+```json
+{
+  "error": "Invalid IMSI format",
+  "details": "IMSI must be exactly 15 digits"
+}
+```
+
+### Update Subscriber
+
+Update an existing subscriber's properties.
+
+```
+PUT /api/v1/subscribers/{imsi}
+```
+
+**Path Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `imsi` | string | 15-digit IMSI of subscriber to update |
+
+**Request Body:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | No | New device name |
+| `apn` | string | No | New Access Point Name |
+| `ip` | string | No | New static IP address |
+
+At least one field must be provided.
+
+**Example Request:**
+```json
+{
+  "name": "Camera-02",
+  "apn": "iot"
+}
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "imsi": "315010000000001",
+  "changes": ["name → Camera-02", "apn → iot"],
+  "message": "Subscriber updated: name → Camera-02, apn → iot"
+}
+```
+
+### Delete Subscriber
+
+Remove a subscriber from the network.
+
+```
+DELETE /api/v1/subscribers/{imsi}
+```
+
+**Path Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `imsi` | string | 15-digit IMSI of subscriber to delete |
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "message": "Subscriber 315010000000001 deleted successfully"
+}
+```
+
+!!! warning
+    Deleting a subscriber immediately disconnects the device from the network.
+
+---
+
+## Network Configuration
+
+### Get Network Configuration
+
+Retrieve current network settings (read-only).
+
+```
+GET /api/v1/config
+```
+
+**Response:**
+```json
+{
+  "timestamp": "2024-01-15 10:30:00 UTC",
+  "host": "10.48.0.110",
+  "network_identity": {
+    "plmnid": "315010",
+    "mcc": "315",
+    "mnc": "010",
+    "network_name": "Open5G2GO",
+    "tac": "1"
+  },
+  "enodeb_config": {
+    "mme_ip": "10.48.0.110",
+    "mme_port": 36412,
+    "plmn_id": "315-010",
+    "tac": 1
+  },
+  "apns": {
+    "total": 1,
+    "list": [
+      {
+        "name": "internet",
+        "downlink_kbps": "100 Mbps",
+        "uplink_kbps": "50 Mbps"
+      }
+    ]
+  },
+  "ip_pool": {
+    "subnet": null,
+    "gateway": null,
+    "start": "10.48.99.2",
+    "end": "10.48.99.254"
+  }
+}
+```
+
+---
+
+## eNodeB Management
+
+### Get eNodeB Status
+
+Retrieve connected eNodeB status and metrics.
+
+```
+GET /api/v1/enodeb/status
+```
+
+**Response:**
+```json
+{
+  "timestamp": "2024-01-15 10:30:00 UTC",
+  "s1ap": {
+    "available": true,
+    "connected_count": 1,
+    "enodebs": [
+      {
+        "serial_number": "120200046421CKY0606",
+        "config_name": "Nova-430i-Test",
+        "location": "Test Lab",
+        "ip_address": "10.48.0.159",
+        "port": 36412,
+        "connected": true,
+        "connected_at": "2024-01-15 10:30:00"
+      }
+    ]
+  },
+  "snmp": {
+    "available": false,
+    "enabled": false,
+    "reachable_count": 0,
+    "enodebs": []
+  },
+  "network": {
+    "plmn": "315010",
+    "mcc": "315",
+    "mnc": "010",
+    "tac": "1",
+    "network_name": "Open5G2GO"
+  }
+}
+```
+
+### Refresh eNodeB Status
+
+Force a refresh of eNodeB status data.
+
+```
+POST /api/v1/enodeb/refresh
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "SAS status refreshed",
+  "timestamp": "2024-01-15 10:30:00 UTC"
+}
+```
+
+---
+
+## Active Connections
+
+### Get Active Connections
+
+Retrieve currently connected devices.
+
+```
+GET /api/v1/connections
+```
+
+**Response:**
+```json
+{
+  "timestamp": "2024-01-15 10:30:00 UTC",
+  "total_active": 2,
+  "connections": [
+    {
+      "imsi": "315010000000001",
+      "name": "Camera-01",
+      "ip": "10.48.99.2",
+      "status": "CONNECTED",
+      "apn": "internet"
+    }
+  ]
+}
+```
+
+---
+
+## Error Handling
+
+All endpoints return consistent error responses:
+
+**Error Response Format:**
+```json
+{
+  "error": "Error message",
+  "details": "Additional context (debug mode only)"
+}
+```
+
+**HTTP Status Codes:**
+
+| Code | Description |
+|------|-------------|
+| 200 | Success |
+| 201 | Created (new subscriber) |
+| 400 | Bad Request (validation error) |
+| 404 | Not Found (subscriber doesn't exist) |
+| 500 | Internal Server Error |
+
+---
+
+## Code Examples
+
+### Python (requests)
+
+```python
+import requests
+
+BASE_URL = "http://localhost:8080/api/v1"
+
+# List all subscribers
+response = requests.get(f"{BASE_URL}/subscribers")
+subscribers = response.json()
+
+# Add a new subscriber
+new_device = {
+    "imsi": "315010000000001",
+    "name": "Camera-01"
+}
+response = requests.post(f"{BASE_URL}/subscribers", json=new_device)
+result = response.json()
+
+# Delete a subscriber
+response = requests.delete(f"{BASE_URL}/subscribers/315010000000001")
+```
+
+### cURL
+
+```bash
+# Health check
+curl http://localhost:8080/api/v1/health
+
+# List subscribers
+curl http://localhost:8080/api/v1/subscribers
+
+# Add subscriber
+curl -X POST http://localhost:8080/api/v1/subscribers \
+  -H "Content-Type: application/json" \
+  -d '{"imsi": "315010000000001", "name": "Camera-01"}'
+
+# Get subscriber details
+curl http://localhost:8080/api/v1/subscribers/315010000000001
+
+# Update subscriber
+curl -X PUT http://localhost:8080/api/v1/subscribers/315010000000001 \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Camera-02"}'
+
+# Delete subscriber
+curl -X DELETE http://localhost:8080/api/v1/subscribers/315010000000001
+
+# Get system status
+curl http://localhost:8080/api/v1/status
+
+# Get network config
+curl http://localhost:8080/api/v1/config
+```
+
+### JavaScript (fetch)
+
+```javascript
+const BASE_URL = 'http://localhost:8080/api/v1';
+
+// List subscribers
+const response = await fetch(`${BASE_URL}/subscribers`);
+const data = await response.json();
+
+// Add subscriber
+const newDevice = {
+  imsi: '315010000000001',
+  name: 'Camera-01'
+};
+
+const addResponse = await fetch(`${BASE_URL}/subscribers`, {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify(newDevice)
+});
+```
+
+---
+
+## Rate Limiting
+
+The MVP does not implement rate limiting. For production deployments, consider adding rate limiting via a reverse proxy (nginx, traefik) or API gateway.
+
+## Authentication
+
+The MVP does not implement authentication. All endpoints are publicly accessible. For production:
+
+- Add API key authentication
+- Implement JWT tokens
+- Use a reverse proxy with authentication
+
+---
+
+## Changelog
+
+| Version | Changes |
+|---------|---------|
+| 0.1.0 | Initial MVP release |

--- a/docs/docs/enodeb-setup.md
+++ b/docs/docs/enodeb-setup.md
@@ -62,8 +62,8 @@ Before configuring your eNodeB, gather the following information:
 |-----------|-------|-------|
 | MME IP Address | Your Docker host IP (e.g., 10.48.0.110) | This is the IP address where your Open5G2GO MME service is running |
 | MME SCTP Port | 36412 | Standard SCTP port for S1AP protocol |
-| MCC (Mobile Country Code) | 315 | Mozambique country code |
-| MNC (Mobile Network Code) | 010 | Mozambique network operator code |
+| MCC (Mobile Country Code) | 315 | US CBRS Private LTE (or your configured MCC) |
+| MNC (Mobile Network Code) | 010 | Private network operator code (or your configured MNC) |
 | TAC (Tracking Area Code) | 1 | Area code for location management |
 
 > **Tip:** To find your Docker host IP, run `hostname -I` on your host machine or check your network configuration. For Docker Desktop, this may be `127.0.0.1` or your machine's local network IP.
@@ -73,16 +73,23 @@ Before configuring your eNodeB, gather the following information:
 ### Access the eNodeB Web Interface
 
 1. Open a web browser
-2. Navigate to the eNodeB's IP address (e.g., `http://192.168.1.100`)
-3. Enter your login credentials (default credentials may vary by firmware version)
+2. Navigate to the eNodeB's IP address (e.g., `http://192.168.150.1`)
+3. Enter your login credentials (default is typically `admin`/`admin`, may vary by firmware version)
 
-### Configure MME Settings
+### Configure via Quick Setting (Baicells)
 
-1. Navigate to **LTE > MME Configuration**
-2. In the MME IP Address field, enter your Docker host IP address
-   - Example: `10.48.0.110`
-3. In the SCTP Port field, enter `36412`
-4. Click **Save** and **Apply** to apply the changes
+For Baicells eNodeBs, the Quick Setting page provides the fastest configuration:
+
+1. Navigate to **Quick Setting**
+2. Enter your PLMN ID (e.g., `315010`) and click the **+** icon to add it
+3. In the **MME IP Address** field, enter your Docker host IP address
+   - Example: `192.168.48.11`
+4. In the **SCTP Port** field, enter `36412`
+5. If necessary, set **TAC** and **S1 port** to match the Network config shown in the SurfControl UI
+6. Click **Save** to apply the changes
+7. Click **admin** in the header and select **Reboot** to apply settings
+
+> **Note:** You may need to remove existing MME IPSEC bindings to update default MME IPs, which are pre-configured for Baicells' Cloud EPC service. Join our Discord community for help with eNodeB configuration.
 
 !!! tip
     The eNodeB will need to establish a network connection to the MME IP address. Ensure that:
@@ -90,25 +97,54 @@ Before configuring your eNodeB, gather the following information:
     - Firewall rules allow traffic on port 36412 (SCTP)
     - The Docker host's firewall is configured to accept S1AP connections
 
-### Configure PLMN Settings
+### Alternative: Manual Configuration
+
+If Quick Setting is not available, configure settings manually:
+
+#### Configure MME Settings
+
+1. Navigate to **LTE > MME Configuration**
+2. In the MME IP Address field, enter your Docker host IP address
+3. In the SCTP Port field, enter `36412`
+4. Click **Save** and **Apply**
+
+#### Configure PLMN Settings
 
 1. Navigate to **LTE > PLMN Configuration**
 2. Set the following parameters:
-   - **MCC (Mobile Country Code):** `315`
-   - **MNC (Mobile Network Code):** `010`
+   - **MCC (Mobile Country Code):** Your configured MCC (e.g., `315`)
+   - **MNC (Mobile Network Code):** Your configured MNC (e.g., `010`)
 3. Enable the PLMN by checking the enable checkbox or toggling the status
 4. Click **Save** and **Apply**
 
 !!! warning
     Ensure the PLMN is enabled after configuration. The eNodeB will not register if the PLMN is disabled.
 
-### Configure TAC (if required)
+#### Configure TAC (if required)
 
 Some eNodeB configurations may require explicit TAC setting:
 
 1. Navigate to **LTE > Cell Configuration** or similar location (varies by firmware)
 2. Set the **TAC (Tracking Area Code)** to `1`
 3. Click **Save** and **Apply**
+
+## SNMP Monitoring Setup (Optional)
+
+SurfControl can read detailed status information from Baicells eNodeBs if SNMP is enabled. This provides enhanced monitoring including RF metrics, traffic statistics, and health indicators on the dashboard.
+
+### Enable SNMP on Baicells eNodeB
+
+1. In the Baicells Management UI, go to **BTS Setting > Management Server**
+2. Set **Source** to `Specific Network`
+3. Set **Source Network** to your LAN subnet (e.g., `192.168.48.0/24`)
+4. Click **Save** and **Apply**
+
+Once configured, the SurfControl dashboard will display detailed eNodeB metrics including:
+- Cell RF status (band, frequency, TX power)
+- Traffic statistics (throughput, PRB usage)
+- Health indicators (CPU, alarms, success rates)
+
+---
 
 ## Verification
 


### PR DESCRIPTION
## Summary

- Syncs Outline public documentation with repo docs (fixes critical issues where install URLs pointed to non-existent repo)
- Adds comprehensive API reference documentation for developers
- Updates eNodeB setup guide with Baicells-specific instructions and SNMP monitoring

## Changes

### Outline Public Docs (via API)
| Document | Changes |
|----------|---------|
| Quick Start Guide | Fixed repo URLs (`open5G2GO` not `openSurfcontrol`), added "Before You Begin" section, fixed IMSI format (full 15-digit), added update instructions |
| What is Open5G2GO? | Updated PLMN to show configurable options |
| SurfControl Dashboard | Fixed IMSI format, updated PLMN info, fixed auth key description |
| eNodeB Setup | Fixed MCC/MNC descriptions (US CBRS, not Mozambique) |
| Troubleshooting | Populated with full content (was empty) |
| API Reference | **NEW** - Created API documentation |

### Repo Docs
- `docs/docs/enodeb-setup.md` - Added Baicells Quick Setting instructions, SNMP monitoring section, fixed MCC/MNC descriptions
- `docs/docs/api-reference.md` - **NEW** comprehensive API documentation with all endpoints, request/response examples, code samples

## Test plan

- [ ] Verify Outline docs render correctly at https://waveriders.getoutline.com
- [ ] Test API documentation endpoints match actual API behavior
- [ ] Verify Quick Start install commands work with correct repo URL

Closes #15

🤖 Generated with [Claude Code](https://claude.ai/code)