### PR TITLE
fix: use nginx proxy port for backend health check (#24)

### DIFF
--- a/scripts/pull-and-run.sh
+++ b/scripts/pull-and-run.sh
@@ -104,7 +104,7 @@ sleep 10
 MAX_ATTEMPTS=30
 ATTEMPT=0
 while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
-    if curl -sf http://localhost:8000/api/v1/health > /dev/null 2>&1; then
+    if curl -sf http://localhost:8080/api/v1/health > /dev/null 2>&1; then
         break
     fi
     ((ATTEMPT++))


### PR DESCRIPTION
## Summary

- Fix backend health check in `pull-and-run.sh` to use port 8080 (nginx proxy) instead of 8000 (direct backend, not accessible from host)

## Test plan

- [x] `curl http://localhost:8080/api/v1/health` returns healthy response
- [ ] Run `./scripts/pull-and-run.sh` — should report success instead of failure

Fixes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)